### PR TITLE
Add reverse map to FeaturesHost

### DIFF
--- a/src/popsift/features.h
+++ b/src/popsift/features.h
@@ -16,6 +16,12 @@ namespace popsift {
 
 struct Descriptor; // float features[128];
 
+struct Match {
+    int x;
+    int y;
+    int z;
+};
+
 /* This is a data structure that is returned to a calling program.
  * The xpos/ypos information in feature is scale-adapted.
  */
@@ -66,6 +72,7 @@ class FeaturesHost : public FeaturesBase
 {
     Feature*     _ext;
     Descriptor*  _ori;
+    int*         _rev;
 
 public:
     FeaturesHost( );
@@ -86,6 +93,7 @@ public:
 
     inline Feature*    getFeatures()    { return _ext; }
     inline Descriptor* getDescriptors() { return _ori; }
+    inline int*        getReverseMap()  { return _rev; }
 
     void print( std::ostream& ostr, bool write_as_uchar ) const;
 
@@ -110,7 +118,7 @@ public:
 
     void reset( int num_ext, int num_ori );
 
-    void match( FeaturesDev* other );
+    void match( FeaturesDev* other, Match* matchOutput = nullptr);
 
     inline Feature*    getFeatures()    { return _ext; }
     inline Descriptor* getDescriptors() { return _ori; }


### PR DESCRIPTION
FeaturesDev contains a reverse map structure that allows you to map from the matched descriptor back to the original feature it represents. We need to have this data on the CPU side so we can properly perform the homography calculation.

To do this I added the same `_rev` field to FeaturesHost and replicated the functionality from FeaturesDev with regards to allocation and freeing the data.

I also added a struct `Match` to represent the CUDA device intrinsic `int3` that is used to represent if a match was accepted and what indexes that matched if it was accepted.