### PR TITLE
Add overload for returning GPU allocated matches.

### DIFF
--- a/src/popsift/features.h
+++ b/src/popsift/features.h
@@ -118,7 +118,8 @@ public:
 
     void reset( int num_ext, int num_ori );
 
-    void match( FeaturesDev* other, Match* matchOutput = nullptr);
+    void match( FeaturesDev* other, Match* matchOutput );
+    int3* match( FeaturesDev* other );
 
     inline Feature*    getFeatures()    { return _ext; }
     inline Descriptor* getDescriptors() { return _ori; }


### PR DESCRIPTION
To help the performance in contexts where the match result is going to be used in the GPU again before it is touched by CPU code I added an overload to match that returns the GPU allocated `int3` array pointer.

This transfers the responsibility of cleaning up the allocation for that array to the caller but saves an extra CPU<->GPU memory transfer if the data is going right back into a function on the GPU.