### PR TITLE
Pre alloc match

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # CMake below 3.4 does not work with CUDA separable compilation at all
 cmake_minimum_required(VERSION 3.12)
 
-project(PopSift VERSION 1.0.0 LANGUAGES CXX)
+project(PopSift VERSION 1.1.0 LANGUAGES CXX)
 
 # Set build path as a folder named as the platform (linux, windows, darwin...) plus the processor type
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/${CMAKE_SYSTEM_NAME}-${CMAKE_SYSTEM_PROCESSOR}")

--- a/src/popsift/features.h
+++ b/src/popsift/features.h
@@ -119,7 +119,8 @@ public:
     void reset( int num_ext, int num_ori );
 
     void match( FeaturesDev* other, Match* matchOutput );
-    int3* match( FeaturesDev* other );
+    int3* match( FeaturesDev* other, cudaStream_t stream = nullptr );
+    void match( FeaturesDev* other, int3* matchMatrix, cudaStream_t stream = nullptr);
 
     inline Feature*    getFeatures()    { return _ext; }
     inline Descriptor* getDescriptors() { return _ori; }


### PR DESCRIPTION
Add a couple of basic things here. Overloaded the `match` function to take a pre-allocated match matrix instead of dynamically allocating a new match matrix for every function call. Also added support for `cudaStreams` and bumped the minor version number to reflect the new changes